### PR TITLE
Add ability to set how truncates work locally vs. one global value.  …

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,47 @@ def entrypoint():
     pass
 ```
 
+By default, local vars will truncate at 500 characters.  This can be changed in one of two ways.
+
+Globally:
+
+```python
+from infi.traceback import set_truncation_limit
+
+set_truncation_limit(100)
+```
+
+and will affect any tracebacks that are hit and if you call it again in different places, both calls will affect the global value for everywhere else.
+
+Per call:
+
+```python
+from infi.traceback import traceback_context, traceback_decorator, pretty_traceback_and_exit_decorator
+
+
+@traceback_decorator(300)
+def test_decorator():
+    import traceback
+    try:
+        call()
+    except:
+       traceback.print_exc()
+
+def test_context():
+    with traceback_context(None):
+        import traceback
+        try:
+            call()
+        except:
+           traceback.print_exc()
+
+@pretty_traceback_and_exit_decorator(100)
+def entrypoint():
+    call()
+```
+
+This gives much more fine grained control when you might want differnt outputs for differnt parts of the code.  None means nothing will be truncated.
+
 Checking out the code
 =====================
 

--- a/src/infi/traceback/tests.py
+++ b/src/infi/traceback/tests.py
@@ -3,6 +3,8 @@ import unittest
 from infi.traceback import pretty_traceback_and_exit_decorator
 from infi.traceback import set_truncation_limit
 
+import infi.traceback
+
 PY3 = sys.version_info[0] == 3
 
 @pretty_traceback_and_exit_decorator
@@ -40,13 +42,14 @@ class TestCase(unittest.TestCase):
         else:
             from StringIO import StringIO
         import sys
+        set_truncation_limit(10)
+        print('after set_truncation_limit', infi.traceback.truncate_repr)
         @pretty_traceback_and_exit_decorator
         def func_with_variable():
             long_variable = "a very long string that we will truncate to 10 chars"
             raise Exception()
         old_stderr = sys.stderr
         sys.stderr = StringIO()
-        set_truncation_limit(10)
         try:
             with self.assertRaises(SystemExit):
                 func_with_variable()
@@ -54,12 +57,14 @@ class TestCase(unittest.TestCase):
             output = sys.stderr.read()
         finally:
             sys.stderr = old_stderr
+        print(output)
+        print('after traceback  set_truncation_limit', infi.traceback.truncate_repr)
         self.assertIn("long_variable", output)
         self.assertIn("func_with_variable", output)
-        self.assertIn("repr truncated", output)
+        self.assertIn("truncated", output)
         self.assertNotIn("10 chars", output)
 
 
 if __name__ == "__main__":
     main()
-    
+


### PR DESCRIPTION
…The global set continues to work.  also changed the format of a truncated value a bit and actually truncate it to the limit set vs. just showing the memory location

I know this is not quire complete.  I couldn't figure out how to run the unit tests correctly.  there was one bug where the original global value is still taking effect (500) even though set_truncation_limit was called.

I think this has something to do with the testing environment because my normal testing showed that this will not happen.  If you can provide some guidance on how to property run the unit tests, i would happily clean up the tests and add a few more wit the functionality I added.

This change should be fully backwards compatible other than I actually truncated the data and changed how it was displayed slight to make it cleaner. All functiontionaly will still work exactly as it did before.

my problem is that if i fully install the package, the test fails as described above (my print statements are still there showing that the global var is set correctly all of the way up until it's used) and if I try to run it in a dir on it's own, it can't find the other infi packages, so not sure what the environment should look like. I just ran nosetests.